### PR TITLE
Revert "Bump pillow from 10.3.0 to 12.1.1 in /script in the pip group across 1 directory"

### DIFF
--- a/script/requirements.txt
+++ b/script/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.32.4
 certifi==2024.7.4
-Pillow==12.1.1
+Pillow==10.3.0


### PR DESCRIPTION
Reverts miaotony/BingImages#20
跑挂了啊，依赖关系Python3.8没这个版本